### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened?
+      placeholder: A clear description of the bug
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should have happened?
+    validations:
+      required: true
+  - type: dropdown
+    id: project
+    attributes:
+      label: Project
+      options:
+        - victus-web-app
+        - victus-ruby-server
+        - victus-home
+        - victus-infra
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical (app crash, data loss)
+        - High (feature broken, no workaround)
+        - Medium (feature broken, workaround exists)
+        - Low (cosmetic, minor inconvenience)
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Screenshots, logs, environment info, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Idea / Discussion
+    url: https://github.com/pedrotroccoli/victus/discussions
+    about: Share ideas or start a discussion

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What feature do you want?
+      placeholder: A clear description of the feature
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this needed? What problem does it solve?
+    validations:
+      required: true
+  - type: textarea
+    id: features
+    attributes:
+      label: Proposed Features
+      description: List the key capabilities
+      placeholder: |
+        - Feature A
+        - Feature B
+        - Feature C
+    validations:
+      required: true
+  - type: dropdown
+    id: project
+    attributes:
+      label: Project
+      multiple: true
+      options:
+        - victus-web-app (frontend)
+        - victus-ruby-server (backend)
+        - victus-home (landing page)
+        - victus-infra
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Mockups, references, related issues, etc.

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,35 @@
+name: Refactor
+description: Propose a code improvement or cleanup
+labels: ["refactor"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What needs refactoring?
+      description: Describe the current state and what should change
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why?
+      description: What problem does this refactor solve? (tech debt, performance, readability, etc.)
+    validations:
+      required: true
+  - type: dropdown
+    id: project
+    attributes:
+      label: Project
+      multiple: true
+      options:
+        - victus-web-app (frontend)
+        - victus-ruby-server (backend)
+        - victus-home (landing page)
+        - victus-infra
+    validations:
+      required: true
+  - type: textarea
+    id: files
+    attributes:
+      label: Files / Areas affected
+      description: List the files or areas of the codebase


### PR DESCRIPTION
## Summary
- Added 3 issue templates: Bug Report, Feature Request, Refactor
- Added config.yml for issue chooser with link to Discussions
- Templates include structured fields: project selector, severity, motivation

## Templates
- **Bug Report** — steps to reproduce, expected behavior, severity, project
- **Feature Request** — description, motivation, proposed features, project
- **Refactor** — what/why, affected files, project

## Test plan
- [ ] Click "New Issue" on the repo and verify the template chooser appears
- [ ] Fill out each template and confirm fields render correctly