### PR TITLE
feat(rate-limit): add rate limiting to API endpoints

### DIFF
--- a/victus-ruby-server/app/controllers/concerns/rate_limited.rb
+++ b/victus-ruby-server/app/controllers/concerns/rate_limited.rb
@@ -1,0 +1,10 @@
+module RateLimited
+  extend ActiveSupport::Concern
+
+  private
+
+  def render_rate_limited
+    response.headers["Retry-After"] = "60"
+    render json: { error: "Rate limit exceeded. Try again later." }, status: :too_many_requests
+  end
+end

--- a/victus-ruby-server/app/controllers/concerns/rate_limited.rb
+++ b/victus-ruby-server/app/controllers/concerns/rate_limited.rb
@@ -3,8 +3,8 @@ module RateLimited
 
   private
 
-  def render_rate_limited
-    response.headers["Retry-After"] = "60"
+  def render_rate_limited(retry_after: 60)
+    response.headers["Retry-After"] = retry_after.to_s
     render json: { error: "Rate limit exceeded. Try again later." }, status: :too_many_requests
   end
 end

--- a/victus-ruby-server/app/controllers/private/private_controller.rb
+++ b/victus-ruby-server/app/controllers/private/private_controller.rb
@@ -1,5 +1,10 @@
 class Private::PrivateController < ApplicationController
   include ActiveAndAuthorized
+  include RateLimited
+
+  rate_limit to: 60, within: 1.minute,
+            by: -> { @current_account&.id || request.remote_ip },
+            with: -> { render_rate_limited }
 
   rescue_from Mongoid::Errors::DocumentNotFound, Mongoid::Errors::InvalidFind, BSON::Error::InvalidObjectId, with: :not_found
 

--- a/victus-ruby-server/app/controllers/public/auth_controller.rb
+++ b/victus-ruby-server/app/controllers/public/auth_controller.rb
@@ -1,5 +1,14 @@
 module Public
   class AuthController < ApplicationController
+    include RateLimited
+
+    rate_limit to: 10, within: 3.minutes, only: [:sign_in, :siwe_verify, :google_auth],
+              with: -> { render_rate_limited }
+    rate_limit to: 5, within: 15.minutes, only: :sign_up,
+              with: -> { render_rate_limited }, name: "sign-up"
+    rate_limit to: 20, within: 3.minutes, only: :start_siwe_auth,
+              with: -> { render_rate_limited }, name: "siwe-nonce"
+
     def sign_in
       accounts_params = params.require(:account).permit(:email, :password)
 

--- a/victus-ruby-server/app/controllers/public/auth_controller.rb
+++ b/victus-ruby-server/app/controllers/public/auth_controller.rb
@@ -3,11 +3,11 @@ module Public
     include RateLimited
 
     rate_limit to: 10, within: 3.minutes, only: [:sign_in, :siwe_verify, :google_auth],
-              with: -> { render_rate_limited }
+              with: -> { render_rate_limited(retry_after: 180) }
     rate_limit to: 5, within: 15.minutes, only: :sign_up,
-              with: -> { render_rate_limited }, name: "sign-up"
+              with: -> { render_rate_limited(retry_after: 900) }, name: "sign-up"
     rate_limit to: 20, within: 3.minutes, only: :start_siwe_auth,
-              with: -> { render_rate_limited }, name: "siwe-nonce"
+              with: -> { render_rate_limited(retry_after: 180) }, name: "siwe-nonce"
 
     def sign_in
       accounts_params = params.require(:account).permit(:email, :password)

--- a/victus-ruby-server/config/environments/development.rb
+++ b/victus-ruby-server/config/environments/development.rb
@@ -17,18 +17,17 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
+  config.cache_store = :memory_store
+
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
   end
 
   config.action_mailer.delivery_method = :test

--- a/victus-ruby-server/config/environments/production.rb
+++ b/victus-ruby-server/config/environments/production.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/victus-ruby-server/config/environments/test.rb
+++ b/victus-ruby-server/config/environments/test.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  config.cache_store = :memory_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/victus-ruby-server/spec/rails_helper.rb
+++ b/victus-ruby-server/spec/rails_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
   # Clean database between tests (Mongoid doesn't use transactions)
   config.before(:each) do
     Mongoid.purge!
+    Rails.cache.clear
   end
 end
 

--- a/victus-ruby-server/spec/requests/api/v1/private/rate_limit_spec.rb
+++ b/victus-ruby-server/spec/requests/api/v1/private/rate_limit_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Private Rate Limiting', type: :request do
+  let(:account) { create(:account, :with_active_subscription) }
+  let(:headers) { { 'Authorization' => "Bearer #{auth_token_for(account)}" } }
+
+  describe 'GET /api/v1/habits' do
+    it 'returns 429 after exceeding per-user rate limit' do
+      61.times do
+        get '/api/v1/habits', headers: headers
+      end
+
+      expect(response).to have_http_status(:too_many_requests)
+      expect(JSON.parse(response.body)['error']).to include('Rate limit')
+      expect(response.headers['Retry-After']).to eq('60')
+    end
+  end
+end

--- a/victus-ruby-server/spec/requests/api/v1/public/auth_rate_limit_spec.rb
+++ b/victus-ruby-server/spec/requests/api/v1/public/auth_rate_limit_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Auth Rate Limiting', type: :request do
 
       expect(response).to have_http_status(:too_many_requests)
       expect(JSON.parse(response.body)['error']).to include('Rate limit')
-      expect(response.headers['Retry-After']).to eq('60')
+      expect(response.headers['Retry-After']).to eq('180')
     end
   end
 

--- a/victus-ruby-server/spec/requests/api/v1/public/auth_rate_limit_spec.rb
+++ b/victus-ruby-server/spec/requests/api/v1/public/auth_rate_limit_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Auth Rate Limiting', type: :request do
+  describe 'POST /api/v1/auth/sign-in' do
+    it 'returns 429 after exceeding rate limit' do
+      11.times do
+        post '/api/v1/auth/sign-in',
+             params: { account: { email: 'test@test.com', password: 'wrong' } },
+             as: :json
+      end
+
+      expect(response).to have_http_status(:too_many_requests)
+      expect(JSON.parse(response.body)['error']).to include('Rate limit')
+      expect(response.headers['Retry-After']).to eq('60')
+    end
+  end
+
+  describe 'POST /api/v1/auth/sign-up' do
+    it 'returns 429 after exceeding sign-up rate limit' do
+      6.times do |i|
+        post '/api/v1/auth/sign-up',
+             params: { account: { name: "User #{i}", email: "user#{i}@test.com", password: 'password123', password_confirmation: 'password123' } },
+             as: :json
+      end
+
+      expect(response).to have_http_status(:too_many_requests)
+      expect(JSON.parse(response.body)['error']).to include('Rate limit')
+    end
+  end
+end

--- a/victus-ruby-server/test/integration/private/rate_limit_test.rb
+++ b/victus-ruby-server/test/integration/private/rate_limit_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+module Private
+  class RateLimitTest < ActionDispatch::IntegrationTest
+    def setup
+      @account = create(:account, :with_active_subscription)
+      @headers = auth_headers(@account)
+    end
+
+    test "returns 429 after exceeding per-user rate limit" do
+      61.times do
+        get "/api/v1/habits", headers: @headers
+      end
+
+      assert_response :too_many_requests
+      json_response = JSON.parse(response.body)
+      assert_includes json_response["error"], "Rate limit"
+      assert_equal "60", response.headers["Retry-After"]
+    end
+
+    test "allows requests under the rate limit" do
+      60.times do
+        get "/api/v1/habits", headers: @headers
+      end
+
+      assert_response :ok
+    end
+  end
+end

--- a/victus-ruby-server/test/integration/public/auth_rate_limit_test.rb
+++ b/victus-ruby-server/test/integration/public/auth_rate_limit_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+module Public
+  class AuthRateLimitTest < ActionDispatch::IntegrationTest
+    # POST /api/v1/auth/sign-in
+    test "returns 429 after exceeding sign-in rate limit" do
+      11.times do
+        post "/api/v1/auth/sign-in",
+             params: { account: { email: "test@test.com", password: "wrong" } }.to_json,
+             headers: { "Content-Type" => "application/json" }
+      end
+
+      assert_response :too_many_requests
+      json_response = JSON.parse(response.body)
+      assert_includes json_response["error"], "Rate limit"
+      assert_equal "60", response.headers["Retry-After"]
+    end
+
+    # POST /api/v1/auth/sign-up
+    test "returns 429 after exceeding sign-up rate limit" do
+      6.times do |i|
+        post "/api/v1/auth/sign-up",
+             params: { account: { name: "User #{i}", email: "user#{i}@test.com", password: "password123", password_confirmation: "password123" } }.to_json,
+             headers: { "Content-Type" => "application/json" }
+      end
+
+      assert_response :too_many_requests
+      json_response = JSON.parse(response.body)
+      assert_includes json_response["error"], "Rate limit"
+    end
+
+    test "allows requests under the sign-in rate limit" do
+      10.times do
+        post "/api/v1/auth/sign-in",
+             params: { account: { email: "test@test.com", password: "wrong" } }.to_json,
+             headers: { "Content-Type" => "application/json" }
+      end
+
+      assert_response :unauthorized
+    end
+  end
+end

--- a/victus-ruby-server/test/integration/public/auth_rate_limit_test.rb
+++ b/victus-ruby-server/test/integration/public/auth_rate_limit_test.rb
@@ -13,7 +13,7 @@ module Public
       assert_response :too_many_requests
       json_response = JSON.parse(response.body)
       assert_includes json_response["error"], "Rate limit"
-      assert_equal "60", response.headers["Retry-After"]
+      assert_equal "180", response.headers["Retry-After"]
     end
 
     # POST /api/v1/auth/sign-up

--- a/victus-ruby-server/test/test_helper.rb
+++ b/victus-ruby-server/test/test_helper.rb
@@ -1,0 +1,20 @@
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
+require "rails/test_help"
+
+class ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+
+  setup do
+    Mongoid.purge!
+    Rails.cache.clear
+  end
+
+  private
+
+  def auth_headers(account)
+    payload = { account_id: account.id.to_s, exp: 24.hours.from_now.to_i }
+    token = JWT.encode(payload, ENV["JWT_SECRET"] || "test_secret", "HS256")
+    { "Authorization" => "Bearer #{token}", "Content-Type" => "application/json" }
+  end
+end


### PR DESCRIPTION
## Summary

Closes #117 (MVP scope)

- Configure `memory_store` cache across all environments (required for Rails 7.2 `rate_limit`)
- Add `RateLimited` concern with JSON 429 response + `Retry-After` header
- IP-based rate limits on public auth endpoints: 10/3min (sign-in, siwe, google), 5/15min (sign-up), 20/3min (siwe-nonce)
- Per-user blanket rate limit on all private endpoints: 60/min
- Uses Rails 7.2 built-in `rate_limit` DSL — zero new gems, aligned with compass

### Deferred (not in scope)
- Tiered limits by pricing plan (#58)
- Abuse detection / unusual pattern detection
- `X-RateLimit-*` headers on every response
- Admin dashboard
- Webhook rate limiting

## Test plan

- [x] Minitest: 5 new integration tests (auth + private rate limits)
- [x] RSpec: 3 new request specs (auth + private rate limits)
- [x] Full minitest suite green (18 tests, 0 failures)
- [x] Full RSpec suite green (285 tests, 0 failures)